### PR TITLE
Add note about accessibility settings for macOS Mojave

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Support media keys (play/pause/prev/next)
 ```bash
 $ ./build.sh
 ```
+
+## Note
+If you're having "Cant bind global shortcut" error on macOS ≥ 10.14 Mojave, you should grant access to the app in Settings -> Security  & Privacy -> Accessibility.


### PR DESCRIPTION
Info: https://electronjs.org/docs/api/global-shortcut#globalshortcutregisteraccelerator-callback

#3 is not obvious to find